### PR TITLE
Pass commit info to grouparoo cli

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
         run: |
           if   [[ '${{ github.event_name }}' == 'push' ]]; then
             echo "COMMIT_SUBJECT=$(git log --format=%s -n 1 ${{ github.sha }})" >> $GITHUB_ENV
-            echo "CONFIG_URL=${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_ENV
+            echo "CONFIG_URL=${{ github.event.push.head_commit.url }}" >> $GITHUB_ENV
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
             echo "CONFIG_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_ENV
           fi

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
       - shell: bash
         run: |
           if   [[ '${{ github.event_name }}' == 'push' ]]; then
-            echo "COMMIT_SUBJECT=$(git log --format=%B -n 1 ${{ github.sha }})" >> $GITHUB_ENV
+            echo "COMMIT_SUBJECT=$(git log --format=%s -n 1 ${{ github.sha }})" >> $GITHUB_ENV
             echo "CONFIG_URL=${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_ENV
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
             echo "CONFIG_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,19 @@ runs:
   steps:
       - run: npm ci
         shell: bash
-      - run: npx grouparoo ${{ inputs.type }} -p ${{ inputs.project_id }}
+      - shell: bash
+        run: |
+          if   [[ '${{ github.event_name }}' == 'push' ]]; then
+            echo "COMMIT_SUBJECT=$(git log --format=%B -n 1 ${{ github.sha }})" >> $GITHUB_ENV
+            echo "CONFIG_URL=${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_ENV
+          elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+            echo "CONFIG_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_ENV
+          fi
+      - run: npx grouparoo ${{ inputs.type }} -p ${{ inputs.project_id }} -m $CONFIG_MESSAGE -u $CONFIG_URL
         shell: bash
         env: 
           GROUPAROO_CLOUD_API_URL: ${{ inputs.api_url }}
           GROUPAROO_CLOUD_API_TOKEN: ${{ inputs.token }}
+          CONFIG_MESSAGE: ${{ env.COMMIT_SUBJECT || github.event.pull_request.title }}
           DATABASE_URL: sqlite://memory
           REDIS_URL: redis://mock


### PR DESCRIPTION
For pushes:
- Message: Latest commit's subject line
- Url: Direct link to the commit

For pull requests:
- Message: Pull request title
- Url: Direct link to the pull request

Initially I tried to just use the latest commit name/link for both `push` and `pull_request` events, but the latest commit on pull requests actually points to a merge commit and is not the one we're interested in. It would be possible to grab the right commit, but it involves changing the fetch depth on the `checkout` step that lives outside of this action and I think the PR name is actually more useful anyway.

There wasn't an initial review for this, so feel free to review the action as a whole @evantahler 